### PR TITLE
Removed '-ljanet' from project.janet as it is being provided by JPM itself

### DIFF
--- a/project.janet
+++ b/project.janet
@@ -19,7 +19,7 @@
             "-I/usr/include/blkid"]
   # pkg-config --libs janet glib-2.0 libsecret-1
  :lflags @["-L/usr/local/lib"
-           "-ljanet"
+#           "-ljanet"
            "-lsecret-1"
            "-lgio-2.0"
            "-lgobject-2.0"


### PR DESCRIPTION
# Problem
The inclusion of `-ljanet` in `project.janet` was causing compilation to fail -
```bash
$ jpm build
compiling secret.c to build/secret.o...
linking build/_secret.so...
/usr/bin/ld: cannot find -ljanet
collect2: error: ld returned 1 exit status
error: command exited with status 1
  in shell [/opt/local/solus/install/janet/v1/bin/jpm] (tailcall) on line 143, column 5
  in do-rule [/opt/local/solus/install/janet/v1/bin/jpm] on line 262, column 26
  in do-rule [/opt/local/solus/install/janet/v1/bin/jpm] (tailcall) on line 258, column 44

```
# Solution
Here is the diff that addresses the issue - 
```bash
$ git diff 
diff --git a/project.janet b/project.janet
index f8b6473..42194fc 100644
--- a/project.janet
+++ b/project.janet
@@ -19,7 +19,7 @@
             "-I/usr/include/blkid"]
   # pkg-config --libs janet glib-2.0 libsecret-1
  :lflags @["-L/usr/local/lib"
-           "-ljanet"
+#           "-ljanet"
            "-lsecret-1"
            "-lgio-2.0"
            "-lgobject-2.0"
```
After this the compilation succeeds -
```bash
$ jpm build
linking build/_secret.so...
generating meta file build/_secret.meta.janet...
compiling secret.c to build/secret.static.o...
creating static library build/_secret.a...

```

# System Info
```bash
## OS = Solus Linux (latest) 64-bit
$ lsb_release -a 
LSB Version:	1.4
Distributor ID:	Solus
Description:	Solus
Release:	4.1
Codename:	fortitude


## Janet runtime 
$ janet -v
1.12.1-meson


## GCC version 
$ gcc --version
gcc (Solus) 9.3.0
Copyright (C) 2019 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

```
